### PR TITLE
avoid server error 500 from Mesomb

### DIFF
--- a/src/Deposit.php
+++ b/src/Deposit.php
@@ -134,6 +134,7 @@ class Deposit
             if (config('mesomb.failed_payments.check')) {
                 CheckFailedTransactions::dispatchNow($this->deposit_model);
             }
+           return $this->deposit_model;
         }
         
         $response->throw();


### PR DESCRIPTION
In case a user tries to withdraw a negative amount or an amount greater than in their account, Mesomb breaks and returns a server error 500. This little edit enables that the model is still returned in this case so that in the controller if the transaction wasn't successful one can return an error message without the app breaking as caused by MeSomb error 500 HTTP response.